### PR TITLE
Removed .only() in a test

### DIFF
--- a/test/DaoModule.spec.ts
+++ b/test/DaoModule.spec.ts
@@ -397,7 +397,7 @@ describe("DaoModule", async () => {
         })
     })
 
-    describe.only("markProposalWithExpiredAnswerAsInvalid", async () => {
+    describe("markProposalWithExpiredAnswerAsInvalid", async () => {
         it("throws if answer cannot expire", async () => {
             const { module } = await setupTestWithTestExecutor();
         


### PR DESCRIPTION
### Motivation
The tests were only running one `describe()`, as it was post-fixed by `.only()`.

### Changes
Removed `.only()` from a `describe()` in test/DaoModule.spec.ts.