### PR TITLE
Chore: Change of variable name executor to avatar

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,5 +1,5 @@
 module.exports = {
-    skipFiles: ['test/Imports.sol', 'test/TestExecutor.sol'],
+    skipFiles: ['test/Imports.sol', 'test/TestAvatar.sol'],
     mocha: {
         grep: "@skip-on-coverage", // Find everything with this tag
         invert: true               // Run the grep's inverse set.

--- a/contracts/DaoModuleERC20.sol
+++ b/contracts/DaoModuleERC20.sol
@@ -6,7 +6,7 @@ import "./interfaces/RealitioV3.sol";
 
 contract DaoModuleERC20 is DaoModule {
     /// @param _owner Address of the owner
-    /// @param _executor Address of the executor (e.g. a Safe)
+    /// @param _avatar Address of the avatar (e.g. a Safe)
     /// @param _oracle Address of the oracle (e.g. Realitio)
     /// @param timeout Timeout in seconds that should be required for the oracle
     /// @param cooldown Cooldown in seconds that should be required after a oracle provided answer
@@ -16,7 +16,7 @@ contract DaoModuleERC20 is DaoModule {
     /// @notice There need to be at least 60 seconds between end of cooldown and expiration
     constructor(
         address _owner,
-        address _executor,
+        address _avatar,
         RealitioV3 _oracle,
         uint32 timeout,
         uint32 cooldown,
@@ -26,7 +26,7 @@ contract DaoModuleERC20 is DaoModule {
     )
         DaoModule(
             _owner,
-            _executor,
+            _avatar,
             _oracle,
             timeout,
             cooldown,

--- a/contracts/DaoModuleETH.sol
+++ b/contracts/DaoModuleETH.sol
@@ -6,7 +6,7 @@ import "./interfaces/RealitioV3.sol";
 
 contract DaoModuleETH is DaoModule {
     /// @param _owner Address of the owner
-    /// @param _executor Address of the executor (e.g. a Safe)
+    /// @param _avatar Address of the avatar (e.g. a Safe)
     /// @param _oracle Address of the oracle (e.g. Realitio)
     /// @param timeout Timeout in seconds that should be required for the oracle
     /// @param cooldown Cooldown in seconds that should be required after a oracle provided answer
@@ -16,7 +16,7 @@ contract DaoModuleETH is DaoModule {
     /// @notice There need to be at least 60 seconds between end of cooldown and expiration
     constructor(
         address _owner,
-        address _executor,
+        address _avatar,
         RealitioV3 _oracle,
         uint32 timeout,
         uint32 cooldown,
@@ -26,7 +26,7 @@ contract DaoModuleETH is DaoModule {
     )
         DaoModule(
             _owner,
-            _executor,
+            _avatar,
             _oracle,
             timeout,
             cooldown,

--- a/contracts/test/TestAvatar.sol
+++ b/contracts/test/TestAvatar.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0;
 
-contract TestExecutor {
+contract TestAvatar {
     address public module;
 
     receive() external payable {}

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -16,7 +16,7 @@ DISCLAIMER: Check the deployed Realitio contracts before using them.
 
 ## Setting up the module
 
-The first step is to deploy the module. Every DAO will have their own module. The module is linked to a DAO (called executor in the contract) and an oracle (e.g. Realitio). These cannot be changed after deployment.
+The first step is to deploy the module. Every DAO will have their own module. The module is linked to a DAO (called avatar in the contract) and an oracle (e.g. Realitio). These cannot be changed after deployment.
 
 As part of the setup you need to define or choose a template on Realitio. More information can be found in [their docs](https://github.com/realitio/realitio-dapp#structuring-and-fetching-information) 
 
@@ -56,7 +56,7 @@ Hardhat tasks can be used to deploy a dao module instance. There are two differe
 
 Now that we have a template, a hardhat task can be used to deploy a DAO module instance. These tasks requires the following parameters:
 
-- `executor` - the address of the executor.
+- `avatar` - the address of the avatar.
 - `owner` - the address of the owner
 - `oracle` - the address of the Realitio contract
 - `template` - the template to be used with Realitio
@@ -64,11 +64,11 @@ Now that we have a template, a hardhat task can be used to deploy a DAO module i
 There are also optional parameters, for more information run `yarn hardhat setup --help` or `yarn hardhat factory-setup --help`.
 
 An example for this on Rinkeby would be:
-`yarn hardhat --network rinkeby setup --owner <owner_address> --executor <executor_address> --oracle 0x3D00D77ee771405628a4bA4913175EcC095538da --template 0x0000000000000000000000000000000000000000000000000000000000000dad`
+`yarn hardhat --network rinkeby setup --owner <owner_address> --avatar <avatar_address> --oracle 0x3D00D77ee771405628a4bA4913175EcC095538da --template 0x0000000000000000000000000000000000000000000000000000000000000dad`
 
 or
 
-`yarn hardhat --network rinkeby factorySetup --factory <factory_address> --mastercopy <mastercopy_address> --owner <owner_address> --executor <executor_address> --oracle 0x3D00D77ee771405628a4bA4913175EcC095538da --template 0x0000000000000000000000000000000000000000000000000000000000000dad`
+`yarn hardhat --network rinkeby factorySetup --factory <factory_address> --mastercopy <mastercopy_address> --owner <owner_address> --avatar <avatar_address> --oracle 0x3D00D77ee771405628a4bA4913175EcC095538da --template 0x0000000000000000000000000000000000000000000000000000000000000dad`
 
 or
 
@@ -79,7 +79,7 @@ This should return the address of the deployed DAO module. For this guide we ass
 Once the module is deployed you should verify the source code (Note: If you used the factory deployment the contract should be already verified). If you use a network that is Etherscan compatible and you configure the `ETHERSCAN_API_KEY` in your environment you can use the provided hardhat task to do this. 
 
 An example for this on Rinkeby would be:
-`yarn hardhat --network rinkeby verifyEtherscan --module 0x4242424242424242424242424242424242424242 --owner <owner_address> --executor <executor_address> --oracle 0x3D00D77ee771405628a4bA4913175EcC095538da --template 0x0000000000000000000000000000000000000000000000000000000000000dad`
+`yarn hardhat --network rinkeby verifyEtherscan --module 0x4242424242424242424242424242424242424242 --owner <owner_address> --avatar <avatar_address> --oracle 0x3D00D77ee771405628a4bA4913175EcC095538da --template 0x0000000000000000000000000000000000000000000000000000000000000dad`
 
 ### Enabling the module
 
@@ -124,7 +124,7 @@ Once the question is available it can be answered via the Realitio web interface
 
 ## Monitoring your module
 
-As anyone can submit proposals to your module it is recommended to setup some monitoring. The DAO module relies on the oracle (e.g. Realitio) to provide the correct answer so that no malicious transactions are executed. In the worst case the executor (e.g. the connected Safe) can invalidate a submitted proposal (see [README](../README.md) for more information). 
+As anyone can submit proposals to your module it is recommended to setup some monitoring. The DAO module relies on the oracle (e.g. Realitio) to provide the correct answer so that no malicious transactions are executed. In the worst case the avatar (e.g. the connected Safe) can invalidate a submitted proposal (see [README](../README.md) for more information). 
 
 To make sure that all the involved stakeholders can react in a timely manner, the events emitted by the module contract should be monitored. Each time a new proposal is submitted the contract will emit a `ProposalQuestionCreated` event with the following parameters:
 ```

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -10,7 +10,7 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 task("setup", "Provides the clearing price to an auction")
     .addParam("owner", "Address of the owner", undefined, types.string)
-    .addParam("executor", "Address of the executor (e.g. Safe)", undefined, types.string)
+    .addParam("avatar", "Address of the avatar (e.g. Safe)", undefined, types.string)
     .addParam("oracle", "Address of the oracle (e.g. Realitio)", undefined, types.string)
     .addParam(
         "template", 
@@ -26,7 +26,7 @@ task("setup", "Provides the clearing price to an auction")
         const [caller] = await hardhatRuntime.ethers.getSigners();
         console.log("Using the account:", caller.address);
         const Module = await hardhatRuntime.ethers.getContractFactory("DaoModule");
-        const module = await Module.deploy(taskArgs.owner, taskArgs.executor, taskArgs.oracle, taskArgs.timeout, taskArgs.cooldown, taskArgs.expiration, taskArgs.bond, taskArgs.template);
+        const module = await Module.deploy(taskArgs.owner, taskArgs.avatar, taskArgs.oracle, taskArgs.timeout, taskArgs.cooldown, taskArgs.expiration, taskArgs.bond, taskArgs.template);
         
         console.log("Module deployed to:", module.address);
     });
@@ -35,7 +35,7 @@ task("factorySetup", "Deploy and initialize DAO Module through a Proxy Factory")
     .addParam("factory", "Address of the Proxy Factory", undefined, types.string)
     .addParam("mastercopy", "Address of the DAO Module Master Copy", undefined, types.string)
     .addParam("owner", "Address of the owner", undefined, types.string)
-    .addParam("executor", "Address of the executor (e.g. Safe)", undefined, types.string)
+    .addParam("avatar", "Address of the avatar (e.g. Safe)", undefined, types.string)
     .addParam("oracle", "Address of the oracle (e.g. Realitio)", undefined, types.string)
     .addParam(
         "template", 
@@ -65,7 +65,7 @@ task("factorySetup", "Deploy and initialize DAO Module through a Proxy Factory")
             ["address", "address", "address", "uint32", "uint32", "uint32", "uint256", "uint256"], 
             [
                 taskArgs.owner,
-                taskArgs.executor,
+                taskArgs.avatar,
                 taskArgs.oracle,
                 taskArgs.timeout,
                 taskArgs.cooldown,
@@ -83,7 +83,7 @@ task("factorySetup", "Deploy and initialize DAO Module through a Proxy Factory")
 task("verifyEtherscan", "Verifies the contract on etherscan")
     .addParam("module", "Address of the module", undefined, types.string)
     .addParam("owner", "Address of the owner", undefined, types.string)
-    .addParam("executor", "Address of the executor (e.g. Safe)", undefined, types.string)
+    .addParam("avatar", "Address of the avatar (e.g. Safe)", undefined, types.string)
     .addParam("oracle", "Address of the oracle (e.g. Realitio)", undefined, types.string)
     .addParam(
         "template", 
@@ -99,7 +99,7 @@ task("verifyEtherscan", "Verifies the contract on etherscan")
         await hardhatRuntime.run("verify", {
             address: taskArgs.module,
             constructorArgsParams: [
-                taskArgs.owner, taskArgs.executor, taskArgs.oracle, `${taskArgs.timeout}`, `${taskArgs.cooldown}`, `${taskArgs.expiration}`, `${taskArgs.bond}`, taskArgs.template
+                taskArgs.owner, taskArgs.avatar, taskArgs.oracle, `${taskArgs.timeout}`, `${taskArgs.cooldown}`, `${taskArgs.expiration}`, `${taskArgs.bond}`, taskArgs.template
             ]
         })
     });

--- a/test/DaoModuleERC20.spec.ts
+++ b/test/DaoModuleERC20.spec.ts
@@ -37,22 +37,22 @@ describe("DaoModuleERC20", async () => {
 
     const baseSetup = deployments.createFixture(async () => {
         await deployments.fixture();
-        const Executor = await hre.ethers.getContractFactory("TestExecutor");
-        const executor = await Executor.deploy();
+        const Avatar = await hre.ethers.getContractFactory("TestAvatar");
+        const avatar = await Avatar.deploy();
         const Mock = await hre.ethers.getContractFactory("MockContract");
         const mock = await Mock.deploy();
         const oracle = await hre.ethers.getContractAt("RealitioV3ERC20", mock.address);
-        return { Executor, executor, module, mock, oracle };
+        return { Avatar, avatar, module, mock, oracle };
     })
 
-    const setupTestWithTestExecutor = deployments.createFixture(async () => {
+    const setupTestWithTestAvatar = deployments.createFixture(async () => {
         const base = await baseSetup();
         const Module = await hre.ethers.getContractFactory("DaoModuleERC20");
-        const module = await Module.deploy(base.executor.address, base.executor.address, base.mock.address, 42, 23, 0, 0, 1337);
+        const module = await Module.deploy(base.avatar.address, base.avatar.address, base.mock.address, 42, 23, 0, 0, 1337);
         return { ...base, Module, module };
     })
 
-    const setupTestWithMockExecutor = deployments.createFixture(async () => {
+    const setupTestWithMockAvatar = deployments.createFixture(async () => {
         const base = await baseSetup();
         const Module = await hre.ethers.getContractFactory("DaoModuleERC20");
         const module = await Module.deploy(base.mock.address, base.mock.address, base.mock.address, 42, 23, 0, 0, 1337);
@@ -70,11 +70,11 @@ describe("DaoModuleERC20", async () => {
             ).to.be.revertedWith("Module is already initialized")
         })
 
-        it("throws if executor is zero address", async () => {
+        it("throws if avatar is zero address", async () => {
             const Module = await hre.ethers.getContractFactory("DaoModuleETH")
             await expect(
                 Module.deploy(user1.address, ZERO_ADDRESS, user1.address, 42, 23, 0, 0, 1337)
-            ).to.be.revertedWith("Executor can not be zero address")
+            ).to.be.revertedWith("Avatar can not be zero address")
         })
 
         it("throws if timeout is 0", async () => {
@@ -99,29 +99,29 @@ describe("DaoModuleERC20", async () => {
 
     describe("setQuestionTimeout", async () => {
         it("throws if Ownable: caller is not the owner", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
             await expect(
                 module.setQuestionTimeout(2)
             ).to.be.revertedWith("Ownable: caller is not the owner");
         })
 
         it("throws if timeout is 0", async () => {
-            const { executor, module } = await setupTestWithTestExecutor();
+            const { avatar, module } = await setupTestWithTestAvatar();
             const calldata = module.interface.encodeFunctionData("setQuestionTimeout", [0])
             await expect(
-                executor.exec(module.address, 0, calldata)
+                avatar.exec(module.address, 0, calldata)
             ).to.be.revertedWith("Timeout has to be greater 0");
         })
 
         it("updates question timeout", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
 
             expect(
                 await module.questionTimeout()
             ).to.be.equals(42);
 
             const calldata = module.interface.encodeFunctionData("setQuestionTimeout", [511])
-            await executor.exec(module.address, 0, calldata)
+            await avatar.exec(module.address, 0, calldata)
 
             expect(
                 await module.questionTimeout()
@@ -131,25 +131,25 @@ describe("DaoModuleERC20", async () => {
 
     describe("setQuestionCooldown", async () => {
         it("throws if Ownable: caller is not the owner", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
             await expect(
                 module.setQuestionCooldown(2)
             ).to.be.revertedWith("Ownable: caller is not the owner");
         })
 
         it("throws if not enough time between cooldown and expiration", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
 
             const setAnswerExpiration = module.interface.encodeFunctionData("setAnswerExpiration", [100])
-            await executor.exec(module.address, 0, setAnswerExpiration)
+            await avatar.exec(module.address, 0, setAnswerExpiration)
 
             const setQuestionCooldownInvalid = module.interface.encodeFunctionData("setQuestionCooldown", [41])
             await expect(
-                executor.exec(module.address, 0, setQuestionCooldownInvalid)
+                avatar.exec(module.address, 0, setQuestionCooldownInvalid)
             ).to.be.revertedWith("There need to be at least 60s between end of cooldown and expiration")
 
             const setQuestionCooldown = module.interface.encodeFunctionData("setQuestionCooldown", [40])
-            await executor.exec(module.address, 0, setQuestionCooldown)
+            await avatar.exec(module.address, 0, setQuestionCooldown)
 
             expect(
                 await module.questionCooldown()
@@ -157,20 +157,20 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("can reset to 0", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
 
             const setAnswerExpiration = module.interface.encodeFunctionData("setAnswerExpiration", [100])
-            await executor.exec(module.address, 0, setAnswerExpiration)
+            await avatar.exec(module.address, 0, setAnswerExpiration)
 
             const setQuestionCooldown = module.interface.encodeFunctionData("setQuestionCooldown", [40])
-            await executor.exec(module.address, 0, setQuestionCooldown)
+            await avatar.exec(module.address, 0, setQuestionCooldown)
 
             expect(
                 await module.questionCooldown()
             ).to.be.equals(40);
 
             const resetQuestionCooldown = module.interface.encodeFunctionData("setQuestionCooldown", [0])
-            await executor.exec(module.address, 0, resetQuestionCooldown)
+            await avatar.exec(module.address, 0, resetQuestionCooldown)
 
             expect(
                 await module.questionCooldown()
@@ -178,14 +178,14 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("updates question cooldown", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
 
             expect(
                 await module.questionCooldown()
             ).to.be.equals(23);
 
             const calldata = module.interface.encodeFunctionData("setQuestionCooldown", [511])
-            await executor.exec(module.address, 0, calldata)
+            await avatar.exec(module.address, 0, calldata)
 
             expect(
                 await module.questionCooldown()
@@ -195,25 +195,25 @@ describe("DaoModuleERC20", async () => {
 
     describe("setAnswerExpiration", async () => {
         it("throws if Ownable: caller is not the owner", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
             await expect(
                 module.setAnswerExpiration(2)
             ).to.be.revertedWith("Ownable: caller is not the owner");
         })
 
         it("throws if not enough time between cooldown and expiration", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
 
             const setQuestionCooldown = module.interface.encodeFunctionData("setQuestionCooldown", [40])
-            await executor.exec(module.address, 0, setQuestionCooldown)
+            await avatar.exec(module.address, 0, setQuestionCooldown)
 
             const setAnswerExpirationInvalid = module.interface.encodeFunctionData("setAnswerExpiration", [99])
             await expect(
-                executor.exec(module.address, 0, setAnswerExpirationInvalid)
+                avatar.exec(module.address, 0, setAnswerExpirationInvalid)
             ).to.be.revertedWith("There need to be at least 60s between end of cooldown and expiration")
 
             const setAnswerExpiration = module.interface.encodeFunctionData("setAnswerExpiration", [100])
-            await executor.exec(module.address, 0, setAnswerExpiration)
+            await avatar.exec(module.address, 0, setAnswerExpiration)
 
             expect(
                 await module.answerExpiration()
@@ -221,14 +221,14 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("updates question cooldown", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
 
             expect(
                 await module.answerExpiration()
             ).to.be.equals(0);
 
             const calldata = module.interface.encodeFunctionData("setAnswerExpiration", [511])
-            await executor.exec(module.address, 0, calldata)
+            await avatar.exec(module.address, 0, calldata)
 
             expect(
                 await module.answerExpiration()
@@ -238,21 +238,21 @@ describe("DaoModuleERC20", async () => {
 
     describe("setArbitrator", async () => {
         it("throws if Ownable: caller is not the owner", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
             await expect(
                 module.setArbitrator(ethers.constants.AddressZero)
             ).to.be.revertedWith("Ownable: caller is not the owner");
         })
 
         it("updates arbitrator", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
 
             expect(
                 await module.questionArbitrator()
-            ).to.be.equals(executor.address);
+            ).to.be.equals(avatar.address);
 
             const calldata = module.interface.encodeFunctionData("setArbitrator", [ethers.constants.AddressZero])
-            await executor.exec(module.address, 0, calldata)
+            await avatar.exec(module.address, 0, calldata)
 
             expect(
                 await module.questionArbitrator()
@@ -262,21 +262,21 @@ describe("DaoModuleERC20", async () => {
 
     describe("setMinimumBond", async () => {
         it("throws if Ownable: caller is not the owner", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
             await expect(
                 module.setMinimumBond(2)
             ).to.be.revertedWith("Ownable: caller is not the owner");
         })
 
         it("updates minimum bond", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
 
             expect(
                 (await module.minimumBond()).toNumber()
             ).to.be.equals(0);
 
             const calldata = module.interface.encodeFunctionData("setMinimumBond", [424242])
-            await executor.exec(module.address, 0, calldata)
+            await avatar.exec(module.address, 0, calldata)
 
             expect(
                 (await module.minimumBond()).toNumber()
@@ -286,21 +286,21 @@ describe("DaoModuleERC20", async () => {
 
     describe("setTemplate", async () => {
         it("throws if Ownable: caller is not the owner", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
             await expect(
                 module.setTemplate(2)
             ).to.be.revertedWith("Ownable: caller is not the owner");
         })
 
         it("updates template", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
 
             expect(
                 (await module.template()).toNumber()
             ).to.be.equals(1337);
 
             const calldata = module.interface.encodeFunctionData("setTemplate", [112358])
-            await executor.exec(module.address, 0, calldata)
+            await avatar.exec(module.address, 0, calldata)
 
             expect(
                 (await module.template()).toNumber()
@@ -310,7 +310,7 @@ describe("DaoModuleERC20", async () => {
 
     describe("markProposalAsInvalidByHash", async () => {
         it("throws if Ownable: caller is not the owner", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
             const randomHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
             await expect(
                 module.markProposalAsInvalidByHash(randomHash)
@@ -318,7 +318,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("marks unknown question id as invalid", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
 
             const randomHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
             expect(
@@ -326,7 +326,7 @@ describe("DaoModuleERC20", async () => {
             ).to.be.equals(ZERO_STATE);
 
             const calldata = module.interface.encodeFunctionData("markProposalAsInvalidByHash", [randomHash])
-            await executor.exec(module.address, 0, calldata)
+            await avatar.exec(module.address, 0, calldata)
 
             expect(
                 await module.questionIds(randomHash)
@@ -334,7 +334,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("marks known question id as invalid", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
             const question = await module.buildQuestion(id, [txHash]);
@@ -351,7 +351,7 @@ describe("DaoModuleERC20", async () => {
             ).to.be.deep.equals(questionId)
 
             const calldata = module.interface.encodeFunctionData("markProposalAsInvalidByHash", [questionHash])
-            await executor.exec(module.address, 0, calldata)
+            await avatar.exec(module.address, 0, calldata)
 
             expect(
                 await module.questionIds(questionHash)
@@ -361,7 +361,7 @@ describe("DaoModuleERC20", async () => {
 
     describe("markProposalAsInvalid", async () => {
         it("throws if Ownable: caller is not the owner", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
             const randomHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
             await expect(
                 module.markProposalAsInvalid(randomHash, [randomHash])
@@ -369,7 +369,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("marks unknown question id as invalid", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -381,7 +381,7 @@ describe("DaoModuleERC20", async () => {
             ).to.be.equals(ZERO_STATE);
 
             const calldata = module.interface.encodeFunctionData("markProposalAsInvalid", [id, [txHash]])
-            await executor.exec(module.address, 0, calldata)
+            await avatar.exec(module.address, 0, calldata)
 
             expect(
                 await module.questionIds(questionHash)
@@ -389,7 +389,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("marks known question id as invalid", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
             const question = await module.buildQuestion(id, [txHash]);
@@ -406,7 +406,7 @@ describe("DaoModuleERC20", async () => {
             ).to.be.deep.equals(questionId)
 
             const calldata = module.interface.encodeFunctionData("markProposalAsInvalid", [id, [txHash]])
-            await executor.exec(module.address, 0, calldata)
+            await avatar.exec(module.address, 0, calldata)
 
             expect(
                 await module.questionIds(questionHash)
@@ -416,7 +416,7 @@ describe("DaoModuleERC20", async () => {
 
     describe("markProposalWithExpiredAnswerAsInvalid", async () => {
         it("throws if answer cannot expire", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
         
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
@@ -429,10 +429,10 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if answer is already invalidated", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
             
             const setAnswerExpiration = module.interface.encodeFunctionData("setAnswerExpiration", [90])
-            await executor.exec(module.address, 0, setAnswerExpiration)
+            await avatar.exec(module.address, 0, setAnswerExpiration)
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -441,7 +441,7 @@ describe("DaoModuleERC20", async () => {
             const questionHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(question))
 
             const markProposalAsInvalidByHash = module.interface.encodeFunctionData("markProposalAsInvalidByHash", [questionHash])
-            await executor.exec(module.address, 0, markProposalAsInvalidByHash)
+            await avatar.exec(module.address, 0, markProposalAsInvalidByHash)
 
             await expect(
                 module.markProposalWithExpiredAnswerAsInvalid(questionHash)
@@ -449,10 +449,10 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if question is unknown", async () => {
-            const { module, executor } = await setupTestWithTestExecutor();
+            const { module, avatar } = await setupTestWithTestAvatar();
             
             const setAnswerExpiration = module.interface.encodeFunctionData("setAnswerExpiration", [90])
-            await executor.exec(module.address, 0, setAnswerExpiration)
+            await avatar.exec(module.address, 0, setAnswerExpiration)
         
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
@@ -465,10 +465,10 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if answer was not accepted", async () => {
-            const { mock, module, executor, oracle } = await setupTestWithTestExecutor();
+            const { mock, module, avatar, oracle } = await setupTestWithTestAvatar();
             
             const setAnswerExpiration = module.interface.encodeFunctionData("setAnswerExpiration", [90])
-            await executor.exec(module.address, 0, setAnswerExpiration)
+            await avatar.exec(module.address, 0, setAnswerExpiration)
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -488,10 +488,10 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if answer is not expired", async () => {
-            const { mock, module, executor, oracle } = await setupTestWithTestExecutor();
+            const { mock, module, avatar, oracle } = await setupTestWithTestAvatar();
             
             const setAnswerExpiration = module.interface.encodeFunctionData("setAnswerExpiration", [90])
-            await executor.exec(module.address, 0, setAnswerExpiration)
+            await avatar.exec(module.address, 0, setAnswerExpiration)
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -512,10 +512,10 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("can mark proposal with expired accepted answer as invalid", async () => {
-            const { mock, module, executor, oracle } = await setupTestWithTestExecutor();
+            const { mock, module, avatar, oracle } = await setupTestWithTestAvatar();
             
             const setAnswerExpiration = module.interface.encodeFunctionData("setAnswerExpiration", [90])
-            await executor.exec(module.address, 0, setAnswerExpiration)
+            await avatar.exec(module.address, 0, setAnswerExpiration)
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -541,7 +541,7 @@ describe("DaoModuleERC20", async () => {
 
     describe("getTransactionHash", async () => {
         it("correctly generates hash for tx without data", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
             const chainId = await module.getChainId()
             const domain = {
                 "chainId": chainId,
@@ -554,7 +554,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("correctly generates hash for complex tx", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
             const chainId = await module.getChainId()
             const domain = {
                 "chainId": chainId,
@@ -569,7 +569,7 @@ describe("DaoModuleERC20", async () => {
 
     describe("buildQuestion", async () => {
         it("concatenats id and hashed hashes as ascii strings", async () => {
-            const { module } = await setupTestWithTestExecutor();
+            const { module } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const tx1Hash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
             const tx2Hash = ethers.utils.solidityKeccak256(["string"], ["some_other_tx_data"]);
@@ -582,7 +582,7 @@ describe("DaoModuleERC20", async () => {
 
     describe("addProposal", async () => {
         it("throws if unexpected question id is returned", async () => {
-            const { module, mock, oracle } = await setupTestWithTestExecutor();
+            const { module, mock, oracle } = await setupTestWithTestAvatar();
             await mock.givenMethodReturnUint(oracle.interface.getSighash("askQuestionWithMinBondERC20"), 42)
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
@@ -592,7 +592,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if proposed question was already invalidated before creation", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
 
@@ -604,7 +604,7 @@ describe("DaoModuleERC20", async () => {
                 "markProposalAsInvalid",
                 [id, [txHash]]
             );
-            await executor.exec(module.address, 0, markInvalid);
+            await avatar.exec(module.address, 0, markInvalid);
 
             await expect(
                 module.addProposal(id, [txHash])
@@ -612,7 +612,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if proposal was already submitted", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
 
@@ -628,7 +628,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if proposal was already submitted when question params were different", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
 
@@ -642,7 +642,7 @@ describe("DaoModuleERC20", async () => {
                 "setQuestionTimeout",
                 [31]
             )
-            await executor.exec(module.address, 0, updateQuestionTimeout)
+            await avatar.exec(module.address, 0, updateQuestionTimeout)
 
             await expect(
                 module.addProposal(id, [txHash])
@@ -650,7 +650,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("calls askQuestionWithMinBondERC20 with correct data", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
 
@@ -667,7 +667,7 @@ describe("DaoModuleERC20", async () => {
                 await module.questionIds(questionHash)
             ).to.be.deep.equals(questionId)
 
-            const askQuestionCalldata = oracle.interface.encodeFunctionData("askQuestionWithMinBondERC20", [1337, question, executor.address, 42, 0, 0, 0, 0])
+            const askQuestionCalldata = oracle.interface.encodeFunctionData("askQuestionWithMinBondERC20", [1337, question, avatar.address, 42, 0, 0, 0, 0])
             expect(
                 (await mock.callStatic.invocationCountForCalldata(askQuestionCalldata)).toNumber()
             ).to.be.equals(1);
@@ -678,7 +678,7 @@ describe("DaoModuleERC20", async () => {
     })
 
     it("calls askQuestionWithMinBondERC20 with correct data when minimum bond is set", async () => {
-        const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+        const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
         const id = "some_random_id";
         const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
 
@@ -686,7 +686,7 @@ describe("DaoModuleERC20", async () => {
             "setMinimumBond",
             [7331]
         )
-        await executor.exec(module.address, 0, setMinimumBond)
+        await avatar.exec(module.address, 0, setMinimumBond)
 
         const question = await module.buildQuestion(id, [txHash]);
         const questionId = await module.getQuestionId(question, 0)
@@ -701,7 +701,7 @@ describe("DaoModuleERC20", async () => {
             await module.questionIds(questionHash)
         ).to.be.deep.equals(questionId)
 
-        const askQuestionCalldata = oracle.interface.encodeFunctionData("askQuestionWithMinBondERC20", [1337, question, executor.address, 42, 0, 0, 7331, 0])
+        const askQuestionCalldata = oracle.interface.encodeFunctionData("askQuestionWithMinBondERC20", [1337, question, avatar.address, 42, 0, 0, 7331, 0])
         expect(
             (await mock.callStatic.invocationCountForCalldata(askQuestionCalldata)).toNumber()
         ).to.be.equals(1);
@@ -712,7 +712,7 @@ describe("DaoModuleERC20", async () => {
 
     describe("addProposalWithNonce", async () => {
         it("throws if previous nonce was not invalid", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             await mock.givenMethodReturnUint(oracle.interface.getSighash("askQuestionWithMinBondERC20"), 42)
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
@@ -727,7 +727,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("calls askQuestionWithMinBondERC20 with correct data", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
 
@@ -750,7 +750,7 @@ describe("DaoModuleERC20", async () => {
                 await module.questionIds(questionHash)
             ).to.be.deep.equals(questionId)
 
-            const askQuestionCalldata = oracle.interface.encodeFunctionData("askQuestionWithMinBondERC20", [1337, question, executor.address, 42, 0, 1, 0, 0])
+            const askQuestionCalldata = oracle.interface.encodeFunctionData("askQuestionWithMinBondERC20", [1337, question, avatar.address, 42, 0, 1, 0, 0])
             expect(
                 (await mock.callStatic.invocationCountForCalldata(askQuestionCalldata)).toNumber()
             ).to.be.equals(1);
@@ -761,7 +761,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("can invalidate after question param change", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
 
@@ -775,7 +775,7 @@ describe("DaoModuleERC20", async () => {
                 "setQuestionTimeout",
                 [23]
             )
-            await executor.exec(module.address, 0, updateQuestionTimeout)
+            await avatar.exec(module.address, 0, updateQuestionTimeout)
 
             const questionId = await module.getQuestionId(question, 11)
             await mock.givenMethodReturnUint(oracle.interface.getSighash("askQuestionWithMinBondERC20"), questionId)
@@ -788,7 +788,7 @@ describe("DaoModuleERC20", async () => {
                 await module.questionIds(questionHash)
             ).to.be.deep.equals(questionId)
 
-            const askQuestionCalldata = oracle.interface.encodeFunctionData("askQuestionWithMinBondERC20", [1337, question, executor.address, 23, 0, 11, 0, 0])
+            const askQuestionCalldata = oracle.interface.encodeFunctionData("askQuestionWithMinBondERC20", [1337, question, avatar.address, 23, 0, 11, 0, 0])
             expect(
                 (await mock.callStatic.invocationCountForCalldata(askQuestionCalldata)).toNumber()
             ).to.be.equals(1);
@@ -799,7 +799,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("can invalidate multiple times", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
 
@@ -832,7 +832,7 @@ describe("DaoModuleERC20", async () => {
                 await module.questionIds(questionHash)
             ).to.be.deep.equals(finalQuestionId)
 
-            const askQuestionCalldata = oracle.interface.encodeFunctionData("askQuestionWithMinBondERC20", [1337, question, executor.address, 42, 0, 1337, 0, 0])
+            const askQuestionCalldata = oracle.interface.encodeFunctionData("askQuestionWithMinBondERC20", [1337, question, avatar.address, 42, 0, 1337, 0, 0])
             expect(
                 (await mock.callStatic.invocationCountForCalldata(askQuestionCalldata)).toNumber()
             ).to.be.equals(1);
@@ -843,7 +843,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("does not create proposal if previous nonce was internally invalidated", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
 
@@ -857,7 +857,7 @@ describe("DaoModuleERC20", async () => {
             await module.addProposal(...proposalParameters)
 
             const markAsInvalidCalldata = module.interface.encodeFunctionData("markProposalAsInvalid", [...proposalParameters])
-            await executor.exec(module.address, 0, markAsInvalidCalldata);
+            await avatar.exec(module.address, 0, markAsInvalidCalldata);
             expect(
                 await module.questionIds(questionHash)
             ).to.deep.equal(INVALIDATED_STATE)
@@ -871,7 +871,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("cannot ask again if follop up was not invalidated", async () => {
-            const { module, mock, oracle, executor } = await setupTestWithTestExecutor();
+            const { module, mock, oracle, avatar } = await setupTestWithTestAvatar();
             const id = "some_random_id";
             const txHash = ethers.utils.solidityKeccak256(["string"], ["some_tx_data"]);
 
@@ -902,7 +902,7 @@ describe("DaoModuleERC20", async () => {
 
     describe("executeProposal", async () => {
         it("throws if question id was not set", async () => {
-            const { module } = await setupTestWithMockExecutor();
+            const { module } = await setupTestWithMockAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -914,7 +914,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if proposal has been invalidated", async () => {
-            const { executor, mock, module, oracle } = await setupTestWithTestExecutor();
+            const { avatar, mock, module, oracle } = await setupTestWithTestAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -929,7 +929,7 @@ describe("DaoModuleERC20", async () => {
                 "markProposalAsInvalid",
                 [id, [txHash]]
             )
-            await executor.exec(module.address, 0, markInvalid)
+            await avatar.exec(module.address, 0, markInvalid)
 
             await expect(
                 module.executeProposal(id, [txHash], tx.to, tx.value, tx.data, tx.operation)
@@ -937,7 +937,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("Proposal stays invalid after question param updates", async () => {
-            const { executor, mock, module, oracle } = await setupTestWithTestExecutor();
+            const { avatar, mock, module, oracle } = await setupTestWithTestAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -952,7 +952,7 @@ describe("DaoModuleERC20", async () => {
                 "markProposalAsInvalid",
                 [id, [txHash]]
             )
-            await executor.exec(module.address, 0, markInvalid)
+            await avatar.exec(module.address, 0, markInvalid)
 
             await expect(
                 module.executeProposal(id, [txHash], tx.to, tx.value, tx.data, tx.operation)
@@ -962,7 +962,7 @@ describe("DaoModuleERC20", async () => {
                 "setQuestionTimeout",
                 [31]
             )
-            await executor.exec(module.address, 0, updateQuestionTimeout)
+            await avatar.exec(module.address, 0, updateQuestionTimeout)
 
             await expect(
                 module.executeProposal(id, [txHash], tx.to, tx.value, tx.data, tx.operation)
@@ -970,7 +970,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if tx data doesn't belong to proposal", async () => {
-            const { mock, module, oracle } = await setupTestWithMockExecutor();
+            const { mock, module, oracle } = await setupTestWithMockAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 1 }
@@ -987,7 +987,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if tx data doesn't belong to questionId", async () => {
-            const { mock, module, oracle } = await setupTestWithMockExecutor();
+            const { mock, module, oracle } = await setupTestWithMockAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -1006,7 +1006,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if tx was not approved", async () => {
-            const { mock, module, oracle } = await setupTestWithMockExecutor();
+            const { mock, module, oracle } = await setupTestWithMockAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -1025,7 +1025,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if bond was not high enough", async () => {
-            const { executor, mock, module, oracle } = await setupTestWithTestExecutor();
+            const { avatar, mock, module, oracle } = await setupTestWithTestAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -1042,7 +1042,7 @@ describe("DaoModuleERC20", async () => {
                 "setMinimumBond",
                 [7331]
             )
-            await executor.exec(module.address, 0, setMinimumBond)
+            await avatar.exec(module.address, 0, setMinimumBond)
 
             await expect(
                 module.executeProposal(id, [txHash], tx.to, tx.value, tx.data, tx.operation)
@@ -1050,7 +1050,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("triggers module transaction when bond is high enough", async () => {
-            const { executor, mock, module, oracle } = await setupTestWithTestExecutor();
+            const { avatar, mock, module, oracle } = await setupTestWithTestAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -1065,8 +1065,8 @@ describe("DaoModuleERC20", async () => {
                 "setMinimumBond",
                 [7331]
             )
-            await executor.exec(module.address, 0, setMinimumBond)
-            await executor.setModule(module.address)
+            await avatar.exec(module.address, 0, setMinimumBond)
+            await avatar.setModule(module.address)
 
             const block = await ethers.provider.getBlock("latest")
             await mock.reset()
@@ -1083,7 +1083,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if cooldown was not over", async () => {
-            const { mock, module, oracle } = await setupTestWithMockExecutor();
+            const { mock, module, oracle } = await setupTestWithMockAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -1104,12 +1104,12 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if answer expired", async () => {
-            const { mock, module, oracle, executor } = await setupTestWithTestExecutor();
+            const { mock, module, oracle, avatar } = await setupTestWithTestAvatar();
 
-            await user1.sendTransaction({ to: executor.address, value: 100 })
-            await executor.setModule(module.address)
+            await user1.sendTransaction({ to: avatar.address, value: 100 })
+            await avatar.setModule(module.address)
             const setAnswerExpiration = module.interface.encodeFunctionData("setAnswerExpiration", [90])
-            await executor.exec(module.address, 0, setAnswerExpiration)
+            await avatar.exec(module.address, 0, setAnswerExpiration)
 
             const id = "some_random_id";
             const tx = { to: mock.address, value: 42, data: "0x", operation: 0, nonce: 0 }
@@ -1122,7 +1122,7 @@ describe("DaoModuleERC20", async () => {
             const block = await ethers.provider.getBlock("latest")
             await mock.givenMethodReturnBool(oracle.interface.getSighash("resultFor"), true)
             await mock.givenMethodReturnUint(oracle.interface.getSighash("getFinalizeTS"), block.timestamp)
-            await mock.givenMethodReturnBool(executor.interface.getSighash("execTransactionFromModule"), true)
+            await mock.givenMethodReturnBool(avatar.interface.getSighash("execTransactionFromModule"), true)
             await nextBlockTime(hre, block.timestamp + 91)
             await expect(
                 module.executeProposal(id, [txHash], tx.to, tx.value, tx.data, tx.operation)
@@ -1130,7 +1130,7 @@ describe("DaoModuleERC20", async () => {
 
             // Reset answer expiration time, so that we can execute the transaction
             const resetAnswerExpiration = module.interface.encodeFunctionData("setAnswerExpiration", [0])
-            await executor.exec(module.address, 0, resetAnswerExpiration)
+            await avatar.exec(module.address, 0, resetAnswerExpiration)
 
             expect(
                 (await mock.callStatic.invocationCount()).toNumber()
@@ -1150,7 +1150,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if tx was already executed for that question", async () => {
-            const { mock, module, oracle, executor } = await setupTestWithMockExecutor();
+            const { mock, module, oracle, avatar } = await setupTestWithMockAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -1163,7 +1163,7 @@ describe("DaoModuleERC20", async () => {
             const block = await ethers.provider.getBlock("latest")
             await mock.givenMethodReturnBool(oracle.interface.getSighash("resultFor"), true)
             await mock.givenMethodReturnUint(oracle.interface.getSighash("getFinalizeTS"), block.timestamp)
-            await mock.givenMethodReturnBool(executor.interface.getSighash("execTransactionFromModule"), true)
+            await mock.givenMethodReturnBool(avatar.interface.getSighash("execTransactionFromModule"), true)
             await nextBlockTime(hre, block.timestamp + 24)
             await module.executeProposal(id, [txHash], tx.to, tx.value, tx.data, tx.operation);
             await expect(
@@ -1172,7 +1172,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if module transaction failed", async () => {
-            const { executor, mock, module, oracle } = await setupTestWithMockExecutor();
+            const { avatar, mock, module, oracle } = await setupTestWithMockAvatar();
 
             const id = "some_random_id";
             const tx = { to: mock.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -1185,7 +1185,7 @@ describe("DaoModuleERC20", async () => {
             const block = await ethers.provider.getBlock("latest")
             await mock.givenMethodReturnBool(oracle.interface.getSighash("resultFor"), true)
             await mock.givenMethodReturnUint(oracle.interface.getSighash("getFinalizeTS"), block.timestamp)
-            await mock.givenMethodReturnBool(executor.interface.getSighash("execTransactionFromModule"), false)
+            await mock.givenMethodReturnBool(avatar.interface.getSighash("execTransactionFromModule"), false)
             await nextBlockTime(hre, block.timestamp + 24)
             expect(
                 (await mock.callStatic.invocationCount()).toNumber()
@@ -1198,7 +1198,7 @@ describe("DaoModuleERC20", async () => {
             ).to.be.equals(false)
 
             // Return success and check that it can be executed
-            await mock.givenMethodReturnBool(executor.interface.getSighash("execTransactionFromModule"), true)
+            await mock.givenMethodReturnBool(avatar.interface.getSighash("execTransactionFromModule"), true)
             await module.executeProposalWithIndex(id, [txHash], tx.to, tx.value, tx.data, tx.operation, tx.nonce);
             expect(
                 await module.executedProposalTransactions(ethers.utils.solidityKeccak256(["string"], [question]), txHash)
@@ -1206,7 +1206,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("triggers module transaction", async () => {
-            const { executor, mock, module, oracle } = await setupTestWithMockExecutor();
+            const { avatar, mock, module, oracle } = await setupTestWithMockAvatar();
 
             const id = "some_random_id";
             const tx = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -1221,7 +1221,7 @@ describe("DaoModuleERC20", async () => {
             await mock.reset()
             await mock.givenMethodReturnBool(oracle.interface.getSighash("resultFor"), true)
             await mock.givenMethodReturnUint(oracle.interface.getSighash("getFinalizeTS"), block.timestamp)
-            await mock.givenMethodReturnBool(executor.interface.getSighash("execTransactionFromModule"), true)
+            await mock.givenMethodReturnBool(avatar.interface.getSighash("execTransactionFromModule"), true)
             await nextBlockTime(hre, block.timestamp + 23)
             await expect(
                 module.executeProposal(id, [txHash], tx.to, tx.value, tx.data, tx.operation)
@@ -1241,7 +1241,7 @@ describe("DaoModuleERC20", async () => {
             expect(
                 (await mock.callStatic.invocationCount()).toNumber()
             ).to.be.equals(1)
-            const execTransactionFromModuleCalldata = executor.interface.encodeFunctionData(
+            const execTransactionFromModuleCalldata = avatar.interface.encodeFunctionData(
                 "execTransactionFromModule",
                 [tx.to, tx.value, tx.data, tx.operation]
             )
@@ -1251,7 +1251,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("throws if previous tx in tx array was not executed yet", async () => {
-            const { mock, module, oracle } = await setupTestWithMockExecutor();
+            const { mock, module, oracle } = await setupTestWithMockAvatar();
 
             const id = "some_random_id";
             const tx1 = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -1273,7 +1273,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("allows to execute the transactions in different blocks", async () => {
-            const { executor, mock, module, oracle } = await setupTestWithMockExecutor();
+            const { avatar, mock, module, oracle } = await setupTestWithMockAvatar();
 
             const id = "some_random_id";
             const tx1 = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -1289,7 +1289,7 @@ describe("DaoModuleERC20", async () => {
             await mock.reset()
             await mock.givenMethodReturnBool(oracle.interface.getSighash("resultFor"), true)
             await mock.givenMethodReturnUint(oracle.interface.getSighash("getFinalizeTS"), block.timestamp)
-            await mock.givenMethodReturnBool(executor.interface.getSighash("execTransactionFromModule"), true)
+            await mock.givenMethodReturnBool(avatar.interface.getSighash("execTransactionFromModule"), true)
             await nextBlockTime(hre, block.timestamp + 24)
 
             await module.executeProposal(id, [tx1Hash, tx2Hash], tx1.to, tx1.value, tx1.data, tx1.operation)
@@ -1298,7 +1298,7 @@ describe("DaoModuleERC20", async () => {
                 await module.executedProposalTransactions(ethers.utils.solidityKeccak256(["string"], [question]), tx1Hash)
             ).to.be.equals(true)
 
-            const execTransaction1FromModuleCalldata = executor.interface.encodeFunctionData(
+            const execTransaction1FromModuleCalldata = avatar.interface.encodeFunctionData(
                 "execTransactionFromModule",
                 [tx1.to, tx1.value, tx1.data, tx1.operation]
             )
@@ -1311,7 +1311,7 @@ describe("DaoModuleERC20", async () => {
             expect(
                 await module.executedProposalTransactions(ethers.utils.solidityKeccak256(["string"], [question]), tx2Hash)
             ).to.be.equals(true)
-            const execTransaction2FromModuleCalldata = executor.interface.encodeFunctionData(
+            const execTransaction2FromModuleCalldata = avatar.interface.encodeFunctionData(
                 "execTransactionFromModule",
                 [tx2.to, tx2.value, tx2.data, tx2.operation]
             )
@@ -1325,7 +1325,7 @@ describe("DaoModuleERC20", async () => {
         })
 
         it("allows to send same tx (with different nonce) multiple times in proposal", async () => {
-            const { executor, mock, module, oracle } = await setupTestWithMockExecutor();
+            const { avatar, mock, module, oracle } = await setupTestWithMockAvatar();
 
             const id = "some_random_id";
             const tx1 = { to: user1.address, value: 0, data: "0xbaddad", operation: 0, nonce: 0 }
@@ -1343,7 +1343,7 @@ describe("DaoModuleERC20", async () => {
             await mock.reset()
             await mock.givenMethodReturnBool(oracle.interface.getSighash("resultFor"), true)
             await mock.givenMethodReturnUint(oracle.interface.getSighash("getFinalizeTS"), block.timestamp)
-            await mock.givenMethodReturnBool(executor.interface.getSighash("execTransactionFromModule"), true)
+            await mock.givenMethodReturnBool(avatar.interface.getSighash("execTransactionFromModule"), true)
             await nextBlockTime(hre, block.timestamp + 24)
 
             await module.executeProposal(id, [tx1Hash, tx2Hash], tx1.to, tx1.value, tx1.data, tx1.operation)
@@ -1352,7 +1352,7 @@ describe("DaoModuleERC20", async () => {
                 await module.executedProposalTransactions(ethers.utils.solidityKeccak256(["string"], [question]), tx1Hash)
             ).to.be.equals(true)
 
-            const execTransactionFromModuleCalldata = executor.interface.encodeFunctionData(
+            const execTransactionFromModuleCalldata = avatar.interface.encodeFunctionData(
                 "execTransactionFromModule",
                 [tx1.to, tx1.value, tx1.data, tx1.operation]
             )


### PR DESCRIPTION
Changes proposed on this proposal:
- `Executor` name has been changed to `Avatar` in tests, documentation, setup scripts, and contracts
- `TestExecutor` file changed to `TestAvatar`

closes #41 